### PR TITLE
feat: TanStack Query / Zustand / Axios Instance 초기설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Camnect (캠넥트)
+# CamNecT (캠넥트)
 
 > 대학생을 위한 동문 네트워킹 & 커피챗 기반 커뮤니티 웹앱
 
-Camnect는
+CamNecT는
 
 동문 탐색, 포트폴리오 공유, 대외활동/팀원 모집, 커피챗(쪽지/채팅)을 통해
 대학생 간 네트워킹을 돕는 웹 애플리케이션입니다.
@@ -11,13 +11,13 @@ Camnect는
 
 ## 🔗 프로젝트 개요
 
-- 프로젝트명: Camnect
+- 프로젝트명: CamNecT
 - 개발 기간: 약 45일
 - 개발 인원: 프론트엔드 3명
 - 프레임워크: React + Vite
 - 스타일링: Tailwind CSS
-- 서버 통신: REST API (React Query)
-- 채팅: MVP는 쪽지형 (추후 WebSocket 실시간 채팅 확장 예정)
+- 서버 통신: REST API (TanStack Query)
+- 채팅: MVP는 polling방식 채팅 (추후 WebSocket 실시간 채팅 확장 예정)
 
 ## 📃 기능 구성
 
@@ -36,12 +36,12 @@ Camnect는
 
 ### 💬 커피챗 / 채팅 기능
 
-**MVP (쪽지형)**
+**MVP (Polling방식)**
 
 - 커피챗 요청
 - 요청함 (수락 / 거절)
-- 쪽지 목록
-- 쪽지 상세
+- 채팅 목록
+- 채팅 상세
 - 읽지 않은 메시지 표시
 
 **확장 (WebSocket, 옵션)**
@@ -96,7 +96,7 @@ Camnect는
 ### 정상현 (인프라 · 인증 · 채팅)
 
 - 공통 인프라 / 프로젝트 기반
-- 인증 & 온보딩 (휴대폰 본인인증)
+- 인증 & 온보딩 (이메일 본인인증)
 - 커피챗 / 쪽지 (MVP)
 - (옵션) WebSocket 실시간 채팅
 
@@ -173,6 +173,7 @@ src/
 ┃
 ┣ hooks/ # custom hooks
 ┣ store/ # 전역 상태 (auth 등)
+┣ types/ # TS interface 정의
 ┣ router/ # 라우팅 설정
 ┣ styles/ # 전역 스타일
 ┣ App.tsx

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mobile": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:mobile": "vite --host",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { useAuthStore } from "../store/useAuthStore";
+
+// Axios 인스턴스 (API 모듈화)
+export const axiosInstance = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    timeout: 9500, // Vercel Proxy는 10초이상 응답 지연 시 504 에러 발생 
+    headers: {
+        "Content-Type": "application/json",
+    }
+});
+
+// Request Interceptor (요청 직전에 수행하는 작업)
+axiosInstance.interceptors.request.use(
+    (config) => {
+        const accessToken = useAuthStore.getState().accessToken;
+
+        if (accessToken) {
+            // 로그인된 유저의 accessToken 붙이기
+            config.headers.Authorization = `Bearer ${accessToken}`;
+        }
+
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
+
+// Response Interceptor
+axiosInstance.interceptors.response.use(
+    (response) => {
+        return response;
+    },
+    (error) => {
+        const status = error.response?.status;
+
+        // Unauthorized (비 로그인 접근 or Token 오류)
+        if (status === 401) {
+            console.log("Unauthorized(401)");
+            // 토큰 만료 시 강제 로그아웃
+            useAuthStore.getState().setLogout();
+        }
+        return Promise.reject(error);
+    }
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+// todo 라우터 구조 import문 들어올 예정
 import App from './App.tsx'
 import './styles/global.css'
 
+const queryClient = new QueryClient(); // 서버 데이터 저장소 -> 저장 / 캐싱 / 관리
+
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <QueryClientProvider client={queryClient}>
+    <StrictMode>
+      <App />
+    </StrictMode>
+  </QueryClientProvider>
 )

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { AuthState } from "../types/auth/authTypes";
+
+// 앱 전체에서 사용하는 로그인 상태 관리
+
+// persist: 새로고침 이후에도 로그인 상태를 유지하기 위함
+// todo JS가 localstorage에 접근하면 토큰 탈취 가능 (추후에 HttpOnly Cookie로 보안강화 가능)
+export const useAuthStore = create(
+    persist<AuthState>(
+        (set) => ({
+            accessToken: null,
+            isAuthenticated: false,
+            user: null,
+            
+            setLogin: (accessToken, user) => set({
+                accessToken: accessToken,
+                isAuthenticated: true,
+                user: user
+            }),
+            setLogout: () => set({
+                accessToken: null,
+                isAuthenticated: false,
+                user: null
+            })
+        }),
+        {
+            name: "auth-storage",
+            storage: createJSONStorage(() => localStorage)
+        }
+    )
+);

--- a/src/types/auth/authTypes.ts
+++ b/src/types/auth/authTypes.ts
@@ -1,10 +1,10 @@
-import type {User} from "../user/userTypes";
+import type { User } from "../user/userTypes";
 
 // 로그인 전역상태의 인터페이스
 export interface AuthState {
-    token: string | null;
+    accessToken: string | null;
     isAuthenticated: boolean;
     user: User | null;
-    setLogin: (token: string, user: User) => void;
+    setLogin: (accessToken: string, user: User) => void;
     setLogout: () => void;
 }   

--- a/src/types/auth/authTypes.ts
+++ b/src/types/auth/authTypes.ts
@@ -1,0 +1,10 @@
+import type {User} from "../user/userTypes";
+
+// 로그인 전역상태의 인터페이스
+export interface AuthState {
+    token: string | null;
+    isAuthenticated: boolean;
+    user: User | null;
+    setLogin: (token: string, user: User) => void;
+    setLogout: () => void;
+}   

--- a/src/types/user/userTypes.ts
+++ b/src/types/user/userTypes.ts
@@ -1,0 +1,4 @@
+export interface User{
+    id: number;
+    name: string;
+}


### PR DESCRIPTION
## 💡 Related issue

- closes #11 

## ✨ Description

**1. TanStack Query 기본 세팅**
- QueryClientProvider를 프로젝트에 주입

**2. 로그인 상태 Zustand 관리**
- 로그인 이후 API 통신들이 이루어지므로 로그인 관련 전역상태 세팅 
- persist 미들웨어로 accessToken을 localStorage에 보관하여 새로고침 시에도 로그인 유지 

**3. API 모듈화 (Axios Instance)**
- API 통신시 전역적인 설정을 모듈로 적용 
  - 서버 요청 baseURL 설정
  - 서버 응답 Timeout 설정 (Vercel Proxy 관련)
  - 서버 요청 시 header 설정
- Request Interceptor : 유저의 accessToken을 붙여서 서버에 요청
- Response Interceptor : 401 Error(UnAuthorized) 핸들링

## 🔨 Implementation Lists

- [ ] TanStackQuery 
- QueryClientProvider 주입
- [ ] useAuthState 구현
- 전역 로그인 상태 구현
- [ ] axiosInstance 구현  
- API 요청 시 request interceptor로 자동 토큰 주입
- [ ] package.json 수정
- npm run dev시 같은 와이파이의 모바일기기로 "Network : 주소" 주소를 입력하면 모바일에서 작업 내용 확인 가능

## ✔️ Checklists

- [x] 모든 테스트 통과
- [x] 최신 develop 브랜치 merge 완료
- [x] 다른 팀원 코드 수정 여부
- [x] 문서 업데이트  

## 📷 Screenshot

## 🔖 Uncompleted Tasks

- 추후 RefreshToken 처리
- RefreshToken처리 시 HttpOnly Cookie 도입

## 📢 To Reviewers (필수)

**Review 사항**
useAuthStore (로그인 zustand 전역상태)에 추가로 넣어야 할 상태가 있을 지 봐주세요

**숙지 사항**
- 앞으로 모든 axios 요청은 axiosInstance로 요청해야 됩니다. (Issue의 참고자료 링크 참조)
- axios Instance 개념 숙지해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 이메일 기반 본인인증 시스템 도입
  * 폴링 기반 채팅 방식으로 변경 (향후 WebSocket 지원 예정)
  * 자동 토큰 관리 및 인증 상태 유지 기능 추가

* **개선 사항**
  * 프로젝트명 및 브랜딩 통일 (CamNecT)
  * API 통신 라이브러리 업데이트

* **Chores**
  * 개발 서버 설정 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->