### PR TITLE
hotfix: HomePage에서도 Notification 못찾을때의 문제 수정 (ios)

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,12 +1,14 @@
 
-import { useMemo, useState, useEffect } from 'react';
-import {FullLayout} from '../../layouts/FullLayout';
-import { HomeHeader } from '../../layouts/headers/HomeHeader';
-import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { requestHome } from '../../api/home';
+import { requestNotificationUnreadCount } from '../../api/notifications';
 import Card from '../../components/Card';
 import PopUp from '../../components/Pop-up';
 import { useFcmToken } from '../../hooks/useFcmNotification';
+import { FullLayout } from '../../layouts/FullLayout';
+import { HomeHeader } from '../../layouts/headers/HomeHeader';
 import { useAuthStore } from '../../store/useAuthStore';
 import { useNotificationStore } from '../../store/useNotificationStore';
 import CoffeeChatBox from './components/CoffeeChatBox';
@@ -15,8 +17,6 @@ import ContestBox from './components/ContestBox';
 import PointBox from './components/PointBox';
 import RecommendBox from './components/RecommendBox';
 import { coffeeChatRequests, contests, homeGreetingUser, recommendList } from './homeData';
-import { requestHome } from '../../api/home';
-import { requestNotificationUnreadCount } from '../../api/notifications';
 import { mapHomeResponseToViewModel } from './homeMapper';
 
 type PopUpConfig = {
@@ -78,6 +78,9 @@ export const HomePage = () => {
 
     useEffect(() => {
         if (!isAuthenticated) return;
+
+        // 브라우저가 Notification API를 지원하는지 확인
+        if (!("Notification" in window)) return;
 
         // 세션 내에 이미 등록을 시도했는지 확인
         const isRegisteredInSession = sessionStorage.getItem('FCM_REGISTERED_IN_SESSION');


### PR DESCRIPTION
## 💡 Related issue


## ✨ Description

- 홈페이지에서도 Notifiaction으로 인한 오류 해결

## 🔨 Implementation Lists

## ✔️ Checklists

- [ ] 모든 테스트 통과
- [ ] 최신 develop 브랜치 merge 완료
- [ ] 다른 팀원 코드 수정 여부
- [ ] 문서 업데이트  
       ex. README에 “인증 플로우/라우트 가드 규칙” 및 에러코드 처리 규칙 추가

## 📷 Screenshot

## 🔖 Uncompleted Tasks


## 📢 To Reviewers (필수)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Notification API를 지원하지 않는 브라우저에서의 오류 방지

* **개선사항**
  * 헤더에 읽지 않은 알림 배지 표시 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->