### PR TITLE
hotfix: socket 연결시점 수정

### DIFF
--- a/src/api/stompClient.ts
+++ b/src/api/stompClient.ts
@@ -3,9 +3,9 @@ import { Client } from "@stomp/stompjs";
 export const stompClient = new Client({
     brokerURL: import.meta.env.VITE_SOCKET_URL,
     // 연결 상태를 로그로 확인
-    debug: (str) => {
-        console.log('STOMP Debug:', str);
-    },
+    // debug: (str) => {
+    //     // console.log('STOMP Debug:', str);
+    // },
     reconnectDelay: 5000, // 연결 끊겼을 때 자동 재연결 간격 (5초)
     // client <-> server 간의 연결 상태를 확인 간격
     heartbeatIncoming: 4000,

--- a/src/hooks/useChatQuery.ts
+++ b/src/hooks/useChatQuery.ts
@@ -30,7 +30,7 @@ export const useUnreadCountQuery = () => {
             const count = response.data.totalUnreadCount;
             return count;
         },
-        enabled: isAuthenticated && !!user?.id,
+        enabled: isAuthenticated && !!user?.id && user?.nextStep === 'HOME',
         staleTime: 1000 * 60, // 1분간 신선도 유지
     });
 };

--- a/src/hooks/useSocketInitializer.ts
+++ b/src/hooks/useSocketInitializer.ts
@@ -10,8 +10,8 @@ export const useSocketInitializer = () => {
 
     // 로그인 상태 바뀔 때만 수행
     useEffect(() => {
-        // 로그아웃 체크
-        if (!isAuthenticated || !user?.id) {
+        // 로그아웃 체크 또는 가입 완료 전(HOME이 아닌 경우) 연결 방지
+        if (!isAuthenticated || !user?.id || user?.nextStep !== 'HOME') {
             if (stompClient.active) {
                 stompClient.deactivate();
             }
@@ -57,6 +57,6 @@ export const useSocketInitializer = () => {
                 stompClient.deactivate();
             }
         }
-    }, [isAuthenticated, user?.id, accessToken, queryClient])
+    }, [isAuthenticated, user?.id, user?.nextStep, accessToken, queryClient])
     
 }

--- a/src/pages/auth/SchoolVerificationStep.tsx
+++ b/src/pages/auth/SchoolVerificationStep.tsx
@@ -103,7 +103,7 @@ export const SchoolVerificationStep = ({ onNext }: SchoolVerificationStepProps) 
 
     // 인증서 제출 함수 
     const handleVerificationSubmit = async () => {
-        if (!verificationFile || !userId) {
+        if (!verificationFile || userId === null || userId === undefined) {
             console.error("제출 실패: 파일 또는 유저 ID가 없습니다.", { verificationFile, userId });
             return;
         }


### PR DESCRIPTION
## 💡 Related issue

## ✨ Description

- socket activate 조건에 nextStep == HOME 추가
완전히 회원가입 된 유저가 로그인시에만 socket activate하여, 가계정 생성 시점의 401로 인한 강제 로그아웃 현상 해결

## 🔨 Implementation Lists

## ✔️ Checklists

- [ ] 모든 테스트 통과
- [ ] 최신 develop 브랜치 merge 완료
- [ ] 다른 팀원 코드 수정 여부
- [ ] 문서 업데이트  
       ex. README에 “인증 플로우/라우트 가드 규칙” 및 에러코드 처리 규칙 추가

## 📷 Screenshot

## 🔖 Uncompleted Tasks



## 📢 To Reviewers (필수)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 학교 인증 단계의 사용자 ID 검증 로직을 개선했습니다.

* **최적화**
  * 불필요한 디버그 로깅을 제거하여 성능을 개선했습니다.
  * 사용자의 온보딩 완료 상태에 따라 채팅 기능의 동작을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->