### PR TITLE
fix: 관리자 로그아웃 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
     check();
   }, []);
 
-  useSocketInitializer(); 
+  useSocketInitializer(); //todo 여기서부터 호출하는 이유?
   useUnreadCountQuery();
   const { popUpConfig, clearPopUpConfig } = useCommunityErrorPopupStore();
 

--- a/src/api-types/stompApiTypes.ts
+++ b/src/api-types/stompApiTypes.ts
@@ -37,11 +37,13 @@ export interface StompMessageRequest {
     content: string;
 }
 
-// 5. 유니온 타입: 소켓으로 받은 데이터에 type 필드가 있으면 읽음 처리, 없으면 일반 메시지
+// 5. Union Type: 같은 주소의 반환값이 두 타입 중 하나
 export type StompChatResponse = StompMessageResponse | StompReadReceiptResponse;
 
 // 타입 가드: 수신된 데이터가 '읽음 처리 데이터'인지 판단
 // (data is StompReadReceiptResponse) : Type predicate (해당 함수가 true면 호출부에서 StompReadReceiptResponse 타입으로 추론)
 export const isReadReceipt = (data: StompChatResponse): data is StompReadReceiptResponse => {
+    // as : casting X, data가 StompMessageResponse면 undefined 
+    // boolean 반환해야 type predicate 사용 가능
     return (data as StompReadReceiptResponse).type === 'READ';
 };

--- a/src/api-types/stompApiTypes.ts
+++ b/src/api-types/stompApiTypes.ts
@@ -28,7 +28,7 @@ export interface StompReadReceiptResponse {
     roomId: number;
     lastReadMessageId: number;
     readAt: string;
-    type?: 'READ'; // 읽었을때만 type필드 추가 
+    type?: 'READ'; // 해당 optional 필드로 읽음여부 판단
 }
 
 // 4. [발행] 메시지 보내기 (/pub/chat/message)
@@ -40,8 +40,8 @@ export interface StompMessageRequest {
 // 5. 유니온 타입: 소켓으로 받은 데이터에 type 필드가 있으면 읽음 처리, 없으면 일반 메시지
 export type StompChatResponse = StompMessageResponse | StompReadReceiptResponse;
 
-// 타입 가드: 수신된 데이터가 읽음 처리 데이터인지 확인하는 함수
-// isReadRecipt가 true이면 data는 StompReadReceiptResponse 타입으로 추론
+// 타입 가드: 수신된 데이터가 '읽음 처리 데이터'인지 판단
+// (data is StompReadReceiptResponse) : Type predicate (해당 함수가 true면 호출부에서 StompReadReceiptResponse 타입으로 추론)
 export const isReadReceipt = (data: StompChatResponse): data is StompReadReceiptResponse => {
     return (data as StompReadReceiptResponse).type === 'READ';
 };

--- a/src/api/stompClient.ts
+++ b/src/api/stompClient.ts
@@ -1,12 +1,14 @@
 import { Client } from "@stomp/stompjs";
 
+// STOMP protocol 처리 객체 (STOMP 규격의 메시지 단위 생성 및 해석)
 export const stompClient = new Client({
-    brokerURL: import.meta.env.VITE_SOCKET_URL,
+    brokerURL: import.meta.env.VITE_SOCKET_URL, // WebSocket pipeline 연결주소 
     // 연결 상태를 로그로 확인
     debug: (str) => {
         console.log('STOMP Debug:', str);
     },
     reconnectDelay: 2000, 
+    // 4초간격으로 서버와 연결확인 
     heartbeatIncoming: 4000,
     heartbeatOutgoing: 4000,
     onWebSocketError: (event) => {

--- a/src/hooks/useSocketInitializer.ts
+++ b/src/hooks/useSocketInitializer.ts
@@ -23,33 +23,36 @@ export const useSocketInitializer = () => {
             Authorization: `Bearer ${accessToken}`,
         };
 
+        // 전역 채팅 목록 구독함수
         const setUpSubscriptions = () => {
              if (!stompClient.connected) return;
              
-            // 전역 채팅 목록 destination
+            // 전역 채팅 목록 destination (개인 채팅방 전체 구독)
             stompClient.subscribe(`/sub/user/${user?.id}/rooms`, () => {
+                // 채팅방 목록 API 갱신
                 queryClient.invalidateQueries({ 
                     queryKey: ['chatRooms'], 
                     exact: false, 
                     refetchType: 'all' 
                 });
 
+                // 안읽은 메시지 개수 API 갱신
                 queryClient.invalidateQueries({
                     queryKey: ['chatUnreadCount']
                 });
             });
         }
 
-        // 연결 성공 후 실행될 단 하나의 마스터 핸들러
+        // socket 연결 성공 후 실행될 단 하나의 마스터 핸들러
         stompClient.onConnect = (frame) => {
             console.log("STOMP 연결 성공! 전역 구독 및 이벤트 발송");
             setUpSubscriptions();
             
-            // 다른 컴포넌트들에게 "연결 완료"를 알림
+            // 다른 컴포넌트들에게 연결 완료 event 알림 (전역상태 사용 X -> 불필요한 리렌더링 방지) 
             window.dispatchEvent(new CustomEvent('stomp-connected', { detail: frame }));
         }
         
-        // 소켓 연결 (비활성 상태일 때만 활성화)
+        // 소켓 연결 (if문으로 검사 이유?)
         if (!stompClient.active) {
             console.log("소켓 활성화 명령");
             stompClient.activate();
@@ -62,6 +65,8 @@ export const useSocketInitializer = () => {
 
         // 앱이 백그라운드에서 돌아왔을 때(visibilitychange) 소켓 재연결
         const handleVisibilityChange = () => {
+
+            // Page visibility API (Web API) : 브라우저 탭이 활성화 되었는지 감지 
             if (document.visibilityState === 'visible') {
                 if (!stompClient.active && isAuthenticated) {
                     console.log("앱 복귀 감지: 소켓 재활성화 시도");
@@ -70,6 +75,7 @@ export const useSocketInitializer = () => {
             }
         };
 
+        // 예약된 이벤트(visibilitychange) 등록 : 브라우저가 자동으로 실행
         document.addEventListener('visibilitychange', handleVisibilityChange);
 
         return () => {

--- a/src/hooks/useStompChat.ts
+++ b/src/hooks/useStompChat.ts
@@ -6,20 +6,22 @@ import { stompClient } from "../api/stompClient";
 
 // 개별 채팅방 구독 및 메시지 송수신을 위한 훅
 export const useStompChat = (roomId: number) => {
-    // 실시간으로 수신된 메시지들 상태 저장 
+    // 실시간으로 수신된 메시지들 저장 
     const [messages, setMessages] = useState<StompMessageResponse[]>([]);
 
-    // 1. 메시지 발행 함수 (발신) - useCallback으로 메모이제이션
+    // 1. 메시지 발행 함수 (발신) - useCallback으로 메모이제이션 
     const sendMessage = useCallback((content: string) => {
         const message: StompMessageRequest = { roomId, content };
 
-        stompClient.publish({
-            destination: `/pub/chat/message`,
-            body: JSON.stringify(message)
-        });
+        if (stompClient.connected) {
+            stompClient.publish({
+                destination: `/pub/chat/message`,
+                body: JSON.stringify(message) // STOMP는 String형태로만 전송가능
+            });
+        }
     }, [roomId]);
 
-    // 2. 채팅방 나가기 함수 - useCallback으로 메모이제이션
+    // 2. 채팅방 나가기 함수 - useCallback으로 메모이제이션 (없었을때의 안읽은 채팅뱃지 개수 문제)
     const leaveChatRoom = useCallback(() => {
         if (stompClient.connected) {
             stompClient.publish({
@@ -30,14 +32,17 @@ export const useStompChat = (roomId: number) => {
 
     // 특정 채팅방 구독 (수신) 및 클린업
     useEffect(() => {
-        let subscription: StompSubscription | null = null;
+        let subscription: StompSubscription | null = null; // 구독 객체
 
+        // 특정 roomId 구독 함수
         const performSubscribe = () => {
             if (!stompClient.connected || subscription) return;
             
             subscription = stompClient.subscribe(`/sub/chat/room/${roomId}`, (message) => {
-                const data: StompChatResponse = JSON.parse(message.body);
+                // 개별 채팅방 구독시의 서버의 응답
+                const data: StompChatResponse = JSON.parse(message.body); // String -> Object 변환 (응답 response)
 
+                // 읽음 type 여부 -> 읽음 처리 로직
                 if (isReadReceipt(data)) {
                     setMessages((prev) => 
                         prev.map((msg) => 
@@ -49,7 +54,7 @@ export const useStompChat = (roomId: number) => {
                     return;
                 }
 
-                setMessages((prev) => [...prev, data]);
+                setMessages((prev) => [...prev, data]); // 일반 메시지일때 병합
             });
         };
 
@@ -60,10 +65,12 @@ export const useStompChat = (roomId: number) => {
         if (stompClient.connected) {
             performSubscribe();
         } else {
+            // stomp-connected 발생 시 performSubscribe(채팅방 구독) 실행
             window.addEventListener('stomp-connected', handleStompConnected);
         }
 
         return () => {
+            // 구독 시 구독취소 로직
             if (subscription) subscription.unsubscribe();
             window.removeEventListener('stomp-connected', handleStompConnected);
             leaveChatRoom();

--- a/src/layouts/headers/MainHeader.tsx
+++ b/src/layouts/headers/MainHeader.tsx
@@ -2,6 +2,8 @@ import type { CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Badge from '../../components/Badge';
 import Icon, { type IconName } from '../../components/Icon';
+import { logout } from '../../api/profileApi';
+import { useAuthStore } from '../../store/useAuthStore';
 
 type HeaderAction = {
   icon: IconName;
@@ -25,6 +27,7 @@ type MainHeaderProps = {
   leftAriaLabel?: string;
   // 뱃지 관련 속성 추가
   showBadge?: boolean;
+  isAdmin?: boolean;
 };
 
 export const MainHeader = ({
@@ -34,13 +37,32 @@ export const MainHeader = ({
   leftIcon,
   leftAriaLabel,
   showBadge,
+  isAdmin,
 }: MainHeaderProps) => {
   const navigate = useNavigate();
+  const setLogout = useAuthStore((s) => s.setLogout);
+  const authUserId = useAuthStore((s) => s.user?.id);
+
+  const handleLogout = async () => {
+    try {
+      const loginUserId = Number(authUserId);
+      if (Number.isFinite(loginUserId)) {
+        await logout(loginUserId);
+      }
+    } catch (e) {
+      console.warn('logout failed:', e);
+    } finally {
+      setLogout();
+      navigate('/login');
+    }
+  };
+
   const normalizedRightActions = rightActions ?? [];
   // 왼쪽 아이콘 기본 동작: 별도 전달이 없으면 mainBack + 뒤로가기(-1)
-  const leftIconName = leftAction?.icon ?? 'mainBack';
-  const leftClickHandler = leftAction?.onClick ?? (() => navigate(-1));
-  const leftLabel = leftAction?.ariaLabel ?? leftAriaLabel ?? '뒤로 가기';
+  // isAdmin인 경우 로그아웃 아이콘과 동작으로 고정
+  const leftIconName = isAdmin ? 'logOut' : (leftAction?.icon ?? 'mainBack');
+  const leftClickHandler = isAdmin ? handleLogout : (leftAction?.onClick ?? (() => navigate(-1)));
+  const leftLabel = isAdmin ? '로그아웃' : (leftAction?.ariaLabel ?? leftAriaLabel ?? '뒤로 가기');
 
   return (
     <header

--- a/src/pages/admin/AdminVerificationList.tsx
+++ b/src/pages/admin/AdminVerificationList.tsx
@@ -98,7 +98,7 @@ export const AdminVerificationList = () => {
     return (
         <AdminFullLayout
             headerSlot={
-                <MainHeader title="증명서 승인 리스트" />
+                <MainHeader title="증명서 승인 리스트" isAdmin={true} />
             }
         >
             <div className="flex flex-col h-full bg-white">

--- a/src/pages/coffee-chat/ChatRoomPage.tsx
+++ b/src/pages/coffee-chat/ChatRoomPage.tsx
@@ -28,7 +28,9 @@ export const ChatRoomPage = () => {
 const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+
     const { user } = useAuthStore();
+
     const { data: chatRoomData, isLoading: isRoomLoading } = useChatRoom(roomId);
     const { mutate: endChat } = useChatRoomClose();
     const { mutate: exitChat } = useChatRoomExit();
@@ -39,7 +41,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     const [isSearching, setIsSearching] = useState(false);
     const [roomSearchQuery, setRoomSearchQuery] = useState("");
 
-    // 소켓 연결 상태를 추적할 로컬 상태 추가 (지연 초기화로 최신 상태 반영)
+    // todo 소켓 연결 상태를 추적할 로컬 상태 추가 (지연 초기화로 최신 상태 반영)
     const [isSocketReady, setIsSocketReady] = useState(() => stompClient.connected);
     
     // 메뉴 관련 상태
@@ -82,7 +84,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
 
     // todo (복습) 실시간 읽음 처리 (Read Receipt) 감시 및 캐시 동기화
     useEffect(() => {
-        // 1. 백그라운드일때 OS가 아예 socket을 종료시켰을수도 있으니 체크
+        // 1. 백그라운드일때 OS가 아예 socket을 종료시켰을수도 있으니 체크 (socketInitializer를 호출하면 되는것 아닌지?)
         if (!stompClient.active) {
             stompClient.activate();
         }
@@ -136,7 +138,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     }, [roomId, queryClient]);
 
     // STOMP 채팅방 나가기 처리 (브라우저 종료/새로고침 대응)
-    // SPA 내부 이동 시 퇴장 처리는 useStompChat 훅의 클린업에서 자동으로 수행됩니다.
+    // SPA 내부 이동 시 퇴장 처리는 useStompChat 훅의 클린업에서 자동으로 수행
     useEffect(() => {
         const handleBeforeUnload = () => {
             leaveChatRoom();
@@ -275,6 +277,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     // 채팅방 나가기 함수 (목록에서 삭제)
     const handleExitChat = () => {
         setIsMenuOpen(false);
+        
         setConfirmPopUpConfig({
             title: "채팅방을 나가시겠습니까?",
             content: "방을 나가면 채팅목록에서 사라지며\n다시 복구할 수 없습니다.",

--- a/src/pages/coffee-chat/ChatRoomPage.tsx
+++ b/src/pages/coffee-chat/ChatRoomPage.tsx
@@ -41,7 +41,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     const [isSearching, setIsSearching] = useState(false);
     const [roomSearchQuery, setRoomSearchQuery] = useState("");
 
-    // todo 소켓 연결 상태를 추적할 로컬 상태 추가 (지연 초기화로 최신 상태 반영)
+    // 소켓 연결 상태를 추적할 로컬 상태 (지연 초기화로 최신 상태 반영)
     const [isSocketReady, setIsSocketReady] = useState(() => stompClient.connected);
     
     // 메뉴 관련 상태
@@ -82,7 +82,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
         };
     }, [isMenuOpen]);
 
-    // todo (복습) 실시간 읽음 처리 (Read Receipt) 감시 및 캐시 동기화
+    // 실시간 읽음 처리 (Read Receipt) 감시 및 캐시 동기화
     useEffect(() => {
         // 1. 백그라운드일때 OS가 아예 socket을 종료시켰을수도 있으니 체크 (socketInitializer를 호출하면 되는것 아닌지?)
         if (!stompClient.active) {
@@ -91,6 +91,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
 
         let subscription: StompSubscription | null = null;
 
+        // 채팅방 구독 함수
         const performSubscribe = () => {
             if (!stompClient.connected || subscription) return;
 
@@ -118,7 +119,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
 
         // 연결 상태 소식 듣기
         const handleStompConnected = () => {
-            console.log("ChatRoomPage: 연결 소식 접수!");
+            console.log("ChatRoomPage: 연결 완료!");
             performSubscribe();
         };
 
@@ -145,6 +146,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
             leaveChatRoom();
         };
 
+        // beforeunload : 브라우저 수준의 종료/새로고침시의 대응
         window.addEventListener('beforeunload', handleBeforeUnload);
         
         return () => {
@@ -162,16 +164,15 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
     const requestInfo = chatRoomData?.requestInfo;
     const isTeamRecruit = requestInfo?.type === 'TEAM_RECRUIT';
 
-    // API로 받은 기존 채팅 내역 데이터들
-    const remoteMessages = useMemo(() => {
-        return chatRoomData?.messages || [];
-    }, [chatRoomData?.messages]);
-
     const myId = String(user?.id);
 
-    // 실시간 메시지를 도메인 타입으로 변환
-    const mappedSocketMessages = useMemo(() => {
-        return socketMessages.map((msg):ChatMessage => ({
+    // 기존 채팅 내역 + 실시간 채팅 내역 병합
+    const allMessages = useMemo(() => {
+        // API로 받은 기존 채팅 내역 데이터들
+        const remoteMessages = chatRoomData?.messages || [];
+
+        // 실시간 메시지를 도메인 타입으로 변환
+        const mappedSocketMessages = socketMessages.map((msg): ChatMessage => ({
             id: String(msg.messageId),
             roomId: String(msg.roomId),
             senderId: String(msg.senderId),
@@ -179,13 +180,10 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
             createdAt: msg.sendDate,
             isRead: msg.read,
             readAt: msg.readAt
-        }))
-    }, [socketMessages]);
+        }));
 
-    // API 데이터와 소켓 메시지를 합치기
-    const allMessages = useMemo(() => {
         return [...remoteMessages, ...mappedSocketMessages];
-    }, [remoteMessages, mappedSocketMessages]);
+    }, [chatRoomData?.messages, socketMessages]);
 
     // 검색어 필터링 적용
     const localMessages = useMemo(() => {
@@ -195,7 +193,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
         );
     }, [allMessages, isSearching, roomSearchQuery]);
 
-    // todo 내가 보낸 제일 마지막 메시지 인덱스 (읽음 표시용)
+    // 내가 보낸 제일 마지막 메시지 인덱스 (읽음 표시용)
     const lastMyMessageIndex = useMemo(() => {
         for (let i = localMessages.length - 1; i >= 0; i--) {
             if (String(localMessages[i].senderId) === myId) return i;
@@ -208,7 +206,7 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
         window.scrollTo(0, document.documentElement.scrollHeight);
     };
 
-    // 1. 레이아웃 안정화 및 초기 스크롤
+    // todo 1. 레이아웃 안정화 및 초기 스크롤
     useLayoutEffect(() => {
         if (!isLoading && !isReady && isSocketReady) {
             if (localMessages.length > 0) {

--- a/src/pages/coffee-chat/ChatRoomPage.tsx
+++ b/src/pages/coffee-chat/ChatRoomPage.tsx
@@ -98,10 +98,11 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
                 const data: StompChatResponse = JSON.parse(message.body);
 
                 if (isReadReceipt(data)) {
+                    // setQueryData : 로컬 캐시 데이터를 업데이트 (updater 함수의 첫 인자는 oldData)
                     queryClient.setQueryData(['chatRoom', roomId], (oldData: ChatRoomDetailData | undefined) => {
                         if (!oldData) return oldData;
                         return {
-                            ...oldData,
+                            ...oldData, // 다른 property들은 유지
                             messages: oldData.messages.map((msg: ChatMessage) => 
                                 Number(msg.id) <= data.lastReadMessageId 
                                     ? { ...msg, isRead: true, readAt: data.readAt } 

--- a/src/pages/coffee-chat/components/ChatList.tsx
+++ b/src/pages/coffee-chat/components/ChatList.tsx
@@ -10,7 +10,7 @@ interface ChatListProps {
 }
 
 // 
-export const ChatList = ({ chatRoom, isFirstPaddingDisabled = true, isClosed = false, onClick }: ChatListProps) => {
+export const ChatList = ({ chatRoom, isFirstPaddingDisabled = false, isClosed = false, onClick }: ChatListProps) => {
     return (
         <li 
             className={`border-b border-gray-150 py-[15px] ${isFirstPaddingDisabled ? 'first:pt-0' : ''} ${isClosed ? 'bg-gray-150' : ''}`}

--- a/src/pages/coffee-chat/components/ChatList.tsx
+++ b/src/pages/coffee-chat/components/ChatList.tsx
@@ -19,50 +19,50 @@ export const ChatList = ({ chatRoom, isFirstPaddingDisabled = true, isClosed = f
                 onClick={onClick}
                 className="flex gap-[12px] px-[25px] w-full text-left cursor-pointer active:bg-gray-100 transition-colors"
             >
-            {/* 프로필 이미지 영역 */}
-            <div className={`shrink-0 ${isClosed ? 'grayscale opacity-50' : ''}`}>
-                {chatRoom.partner.profileImg ? (
-                    <img src={chatRoom.partner.profileImg} alt="프로필 이미지" className="w-[60px] h-[60px] rounded-full object-cover" />
-                ) : (
-                    <div className="w-[60px] h-[60px] rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
-                        <span className="text-gray-500 text-[18px] font-bold">{chatRoom.partner.name.charAt(0)}</span>
-                    </div>
-                )}
-            </div>
-
-            {/* 정보 영역 */}
-            <div className={`flex flex-col justify-center flex-1 min-w-0 gap-[5px] ${isClosed ? 'opacity-60' : ''}`}>
-                <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-[4px] min-w-0">
-                        <span className={`flex-none text-[18px] font-bold leading-[140%] tracking-[-0.36px] truncate ${isClosed ? 'text-gray-800' : 'text-[#202023]'}`}>
-                            {chatRoom.partner.name}
-                        </span>
-                        <span className="truncate text-[14px] font-normal text-gray-800 leading-[140%] tracking-[-0.56px] whitespace-nowrap">
-                            · {chatRoom.partner.major} {!isNaN(Number(chatRoom.partner.studentId)) && chatRoom.partner.studentId.length >= 2 ? `${chatRoom.partner.studentId.slice(2, 4)}학번` : chatRoom.partner.studentId}
-                        </span>
-                    </div>
-                    {/* 날짜 */}
-                    <span className="text-[12px] font-normal text-[#A1A1A1] leading-[140%] tracking-[-0.24px] whitespace-nowrap ml-[8px]">
-                        {formatDate(chatRoom.lastMessageDate)}
-                    </span>
-                </div>
-                
-                <div className="flex justify-between items-center">
-                    {/* 마지막 메시지 */}
-                    <span className={`text-[14px] font-normal leading-[140%] tracking-[-0.56px] truncate pr-[10px] ${isClosed ? 'text-gray-800' : 'text-[#646464]'}`}>
-                        {chatRoom.lastMessage}
-                    </span>
-                    
-                    {/* 안읽은 메시지 뱃지 (종료된 방은 보통 뱃지를 숨기거나 흐리게 처리함) */}
-                    {chatRoom.unreadCount > 0 && !isClosed && (
-                        <div className="flex-none w-[20px] h-[20px] px-[6px] rounded-full bg-primary flex items-center justify-center">
-                            <span className="text-[12px] font-bold text-white leading-none">
-                                {chatRoom.unreadCount}
-                            </span>
+                {/* 프로필 이미지 영역 */}
+                <div className={`shrink-0 ${isClosed ? 'grayscale opacity-50' : ''}`}>
+                    {chatRoom.partner.profileImg ? (
+                        <img src={chatRoom.partner.profileImg} alt="프로필 이미지" className="w-[60px] h-[60px] rounded-full object-cover" />
+                    ) : (
+                        <div className="w-[60px] h-[60px] rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
+                            <span className="text-gray-500 text-[18px] font-bold">{chatRoom.partner.name.charAt(0)}</span>
                         </div>
                     )}
                 </div>
-            </div>
+
+                {/* 정보 영역 */}
+                <div className={`flex flex-col justify-center flex-1 min-w-0 gap-[5px] ${isClosed ? 'opacity-60' : ''}`}>
+                    <div className="flex justify-between items-center">
+                        <div className="flex items-center gap-[4px] min-w-0">
+                            <span className={`flex-none text-[18px] font-bold leading-[140%] tracking-[-0.36px] truncate ${isClosed ? 'text-gray-800' : 'text-[#202023]'}`}>
+                                {chatRoom.partner.name}
+                            </span>
+                            <span className="truncate text-[14px] font-normal text-gray-800 leading-[140%] tracking-[-0.56px] whitespace-nowrap">
+                                · {chatRoom.partner.major} {!isNaN(Number(chatRoom.partner.studentId)) && chatRoom.partner.studentId.length >= 2 ? `${chatRoom.partner.studentId.slice(2, 4)}학번` : chatRoom.partner.studentId}
+                            </span>
+                        </div>
+                        {/* 날짜 */}
+                        <span className="text-[12px] font-normal text-[#A1A1A1] leading-[140%] tracking-[-0.24px] whitespace-nowrap ml-[8px]">
+                            {formatDate(chatRoom.lastMessageDate)}
+                        </span>
+                    </div>
+                    
+                    <div className="flex justify-between items-center">
+                        {/* 마지막 메시지 */}
+                        <span className={`text-[14px] font-normal leading-[140%] tracking-[-0.56px] truncate pr-[10px] ${isClosed ? 'text-gray-800' : 'text-[#646464]'}`}>
+                            {chatRoom.lastMessage}
+                        </span>
+                        
+                        {/* 안읽은 메시지 뱃지 (종료된 방은 보통 뱃지를 숨기거나 흐리게 처리함) */}
+                        {chatRoom.unreadCount > 0 && !isClosed && (
+                            <div className="flex-none w-[20px] h-[20px] px-[6px] rounded-full bg-primary flex items-center justify-center">
+                                <span className="text-[12px] font-bold text-white leading-none">
+                                    {chatRoom.unreadCount}
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                </div>
             </button>
         </li>
     );


### PR DESCRIPTION
## 💡 Related issue

- closes #115 

## ✨ Description

- 채팅 로직 주석 추가
- 관리자 로그아웃 기능 추가
- 채팅 리스트 패딩 일부 수정
-> first요소 padding top추가 (채팅 종료시 배경색 변화 영역 수정)

## 🔨 Implementation Lists

## ✔️ Checklists

- [ ] 모든 테스트 통과
- [ ] 최신 develop 브랜치 merge 완료
- [ ] 다른 팀원 코드 수정 여부
- [ ] 문서 업데이트  

## 📷 Screenshot
**관리자 로그아웃**
<img width="445" height="110" alt="image" src="https://github.com/user-attachments/assets/394c6334-2c35-4c32-ba05-53583c8c6d18" />

**채팅 리스트 수정**
Before
<img width="457" height="878" alt="이미지" src="https://github.com/user-attachments/assets/928a6570-100d-47b9-9af3-a8b642a65a3d" />
After
<img width="441" height="873" alt="이미지 (1)" src="https://github.com/user-attachments/assets/6fad1f5b-801e-433d-8a59-5f4af2be894a" />

## 🔖 Uncompleted Tasks

- [ ] 채팅 리스트 방의 연속 종료시, 경계선 사라짐으로 인한 식별 문제 
-> 디자이너와 의논 필요
- [ ] 채팅 버그 수정
- [ ] 아이디 / 비밀번호 찾기
- [ ] 담당 도메인 학번 2자리 입력 파싱

## 📢 To Reviewers (필수)

- 이번 이슈는 기존 리뷰 브랜치가 merge되지 않았어서 해당 브랜치 이름으로 마저 작업했습니다.
- 채팅방 상세 페이지에서 기본 프로필 이미지 깨짐 문제는 BE의 API 응답 값이 변화하면 해결되는 문제입니다. (연락 완료)
