### PR TITLE
fix : 초기 회원가입 유저 채팅 오류 해결

### DIFF
--- a/src/pages/auth/SchoolCompletion.tsx
+++ b/src/pages/auth/SchoolCompletion.tsx
@@ -65,7 +65,14 @@ export const SchoolCompletion = () => {
                     {/* <ButtonWhite label = "재인증" /> */}
                     <Button 
                         label="시작하기"
-                        onClick={() => navigate('/home')}
+                        onClick={() => {
+                            // useAuthStore의 nextStep을 HOME으로 변경
+                            useAuthStore.setState((state) => ({
+                                user: state.user ? { ...state.user, nextStep: 'HOME' } : null
+                            }));
+                            // 홈 화면 이동
+                            navigate('/home');
+                        }}
                     />
                 </div>
             </div>

--- a/src/pages/coffee-chat/ChatRoomPage.tsx
+++ b/src/pages/coffee-chat/ChatRoomPage.tsx
@@ -84,11 +84,6 @@ const ChatRoomContent = ({ roomId }: { roomId: string }) => {
 
     // 실시간 읽음 처리 (Read Receipt) 감시 및 캐시 동기화
     useEffect(() => {
-        // 1. 백그라운드일때 OS가 아예 socket을 종료시켰을수도 있으니 체크 (socketInitializer를 호출하면 되는것 아닌지?)
-        if (!stompClient.active) {
-            stompClient.activate();
-        }
-
         let subscription: StompSubscription | null = null;
 
         // 채팅방 구독 함수


### PR DESCRIPTION
## 💡 Related issue

- closes #121 

## ✨ Description

**오류 원인**
- 회원가입 완료 페이지 -> 홈 페이지 처음 진입시, nextStep 전역상태의 업데이트가 안되서 socket 연결 조건문을 통과하지 못하여 STOMP 연결이 불가 했음
  - accessToken : Null
- 로그아웃 이후에는 서버가 nextStep을 업데이트하여 STOMP 연결 가능 (오류 X)


## 🔨 Implementation Lists

- [ ] 전역상태 업데이트
- 첫 홈화면 진입 시, nextStep == "HOME"으로 업데이트 
- [ ] STOMP 연결 로직 수정 
- ChatRoomPage 컴포넌트에서 소켓 연결 로직 삭제 
  - STOMP연결은, useSocketInitializer에서만 수행 

## ✔️ Checklists

- [ ] 모든 테스트 통과
- [ ] 최신 develop 브랜치 merge 완료
- [ ] 다른 팀원 코드 수정 여부

## 📷 Screenshot
<img width="1920" height="2282" alt="BAC17EA2-D0C5-471E-A651-A12EC9769195" src="https://github.com/user-attachments/assets/9610f46c-e528-43f0-aa3e-f5f6f9acb64a" />

## 🔖 Uncompleted Tasks

- [ ] 탈퇴한 사용자 이미지깨짐 문제 파악 (채팅목록에서)

## 📢 To Reviewers (필수)

- 해당 브랜치에서 개발 서버를 실행하고, 개발서버에서 회원가입을 실시하여, 다른 기기로 로그인 된 기존 계정으로부터 커피챗이 잘 동작하는지 확인해주세요.
(PC 개발 서버 : 테스트 계정, 다른 기기 : 기존 계정)

- 테스트 계정은 로그아웃을 하지말고 테스트하셔야 됩니다. 로그아웃 이후에는 정상동작합니다.

- 테스트 이후에는 테스트 계정을 탈퇴해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user state not being properly tracked when completing school registration and navigating to home.

* **Refactor**
  * Simplified chat subscription initialization logic by removing unnecessary socket activation check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CamNecT/CamNecT-Web/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->