### PR TITLE
Feat: 관리자 대외활동 탭

### DIFF
--- a/src/pages/activity/ActivityPostPage.tsx
+++ b/src/pages/activity/ActivityPostPage.tsx
@@ -30,6 +30,8 @@ const ActivityPostPage = () => {
   const { postId } = useParams();
   const navigate = useNavigate();
   const authUser = useAuthStore((state) => state.user);
+  const userRole = authUser?.role;
+  const isAdmin = userRole === 'ADMIN';
   const userId = authUser?.id ? parseInt(authUser.id) : null;
   const activityId = postId ? parseInt(postId) : null;
 
@@ -82,6 +84,7 @@ const ActivityPostPage = () => {
       key={selectedPost.id} 
       selectedPost={selectedPost}
       isMine={detailResponse.data.isMine}
+      isAdmin={isAdmin}
       activityId={activityId!}
       userId={userId!}
       initialIsBookmarked={detailResponse.data.isBookmarked}
@@ -93,6 +96,7 @@ const ActivityPostPage = () => {
 type ActivityPostContentProps = {
   selectedPost: ReturnType<typeof mapDetailToActivityPost>;
   isMine: boolean;
+  isAdmin: boolean;
   activityId: number;
   userId: number;
   initialIsBookmarked: boolean;
@@ -102,6 +106,7 @@ type ActivityPostContentProps = {
 const ActivityPostContent = ({ 
   selectedPost,
   isMine,
+  isAdmin,
   activityId,
   userId,
   initialIsBookmarked,
@@ -152,15 +157,19 @@ const ActivityPostContent = ({
     },
   });
 
-  const optionItems: OptionItem[] = isMine
-    ? [
-        { id: 'edit-post', icon: 'edit', label: '게시글 수정' },
-        { id: 'delete-post', icon: 'delete', label: '게시글 삭제' },
-      ]
-    : [
-        { id: 'copy-url', icon: 'url', label: 'URL 복사' },
-        { id: 'report-post', icon: 'report', label: '게시글 신고' },
-      ];
+  const optionItems: OptionItem[] = isAdmin
+  ? [
+      { id: 'delete-post', icon: 'delete', label: '게시글 삭제' },
+    ]
+    : isMine
+      ? [
+          { id: 'edit-post', icon: 'edit', label: '게시글 수정' },
+          { id: 'delete-post', icon: 'delete', label: '게시글 삭제' },
+        ]
+      : [
+          { id: 'copy-url', icon: 'url', label: 'URL 복사' },
+          { id: 'report-post', icon: 'report', label: '게시글 신고' },
+        ];
 
   const handleOptionClick = async (item: OptionItem) => {
     if (item.id === 'copy-url') {

--- a/src/pages/activity/WritePage.tsx
+++ b/src/pages/activity/WritePage.tsx
@@ -395,7 +395,7 @@ export const ActivityWritePage = () => {
     <EmptyLayout>
       <div className='flex w-full flex-col bg-white overflow-hidden min-h-0' style={{ height: `${viewportHeight}px` }}>
         <header
-          className='flex w-full shrink-0 items-center justify-between bg-white'
+          className='flex w-full shrink-0 items-center justify-between bg-white sticky left-0 right-0 top-0'
           style={{
             padding: '10px 25px',
             paddingTop: 'calc(10px + env(safe-area-inset-top, 0px))',

--- a/src/pages/admin/AdminWritePage.tsx
+++ b/src/pages/admin/AdminWritePage.tsx
@@ -6,18 +6,24 @@ import ExternalTab from '../activity/tabs/ExternalTab';
 import JobTab from '../activity/tabs/JobTab';
 import type { ActivityPostTab } from '../../types/activityPage/activityPageTypes';
 import { AdminFullLayout } from '../../layouts/AdminFullLayout';
+import ClubTab from '../activity/tabs/ClubTab';
+import StudyTab from '../activity/tabs/StudyTab';
 
 const tabItems: TabItem[] = [
+  { id: 'club', label: '동아리' },
+  { id: 'study', label: '스터디' },
   { id: 'external', label: '대외활동' },
   { id: 'job', label: '취업정보' },
 ];
 
 export const AdminWritePage = () => {
-  const [activeTab, setActiveTab] = useState<ActivityPostTab>('external')
+  const [activeTab, setActiveTab] = useState<ActivityPostTab>('club')
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
   const renderTab = () => {
+    if (activeTab === 'club') return <ClubTab searchQuery={searchQuery} />;
+    if (activeTab === 'study') return <StudyTab searchQuery={searchQuery} />;
     if (activeTab === 'external') return <ExternalTab searchQuery={searchQuery} isAdmin={true}/>;
     return <JobTab searchQuery={searchQuery} isAdmin={true}/>;
   };


### PR DESCRIPTION
## 💡 Related issue

- closes #123

## ✨ Description

- 관리자 대외활동 탭(동아리, 스터디) 다시 연결
- 타 유저의 대외활동 게시글을 관리자가 삭제할 수 있도록 권한 부여
- 대외활동 글 생성 화면 헤더 고정

## 🔨 Implementation Lists


## ✔️ Checklists

- [ ] 모든 테스트 통과
- [ ] 최신 develop 브랜치 merge 완료
- [ ] 다른 팀원 코드 수정 여부
- [ ] 문서 업데이트  
       ex. README에 “인증 플로우/라우트 가드 규칙” 및 에러코드 처리 규칙 추가

## 📷 Screenshot
<img width="417" height="732" alt="image" src="https://github.com/user-attachments/assets/979b9f4c-e686-436b-ad3b-8e971f172bdf" />

## 🔖 Uncompleted Tasks

- [ ] 관리자 기능에 신고 화면 추가

## 📢 To Reviewers (필수)

- 글 생성 화면 헤더의 스크롤이 막아지는지 확인 부탁드립니다!
- 관리자 글 삭제는 이미 테스트를 통해 기능하는 것 확인했습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Admin post creation now includes additional tabs for **Club** and **Study** content, with Club selected by default.
  - Post actions now vary by role: admins see only **Delete**, while other users keep the prior edit/delete, copy link, and report options.

- **Bug Fixes**
  - The post editor header now stays pinned at the top while scrolling for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->