### PR TITLE
hotfix : Header UI 수정

### DIFF
--- a/src/components/ButtonWhite.tsx
+++ b/src/components/ButtonWhite.tsx
@@ -9,14 +9,14 @@ const ButtonWhite = ({ label, className = '', disabled, ...props}: ButtonWhitePr
   return (
     <button
       disabled={disabled}
-      className={`${twMerge(
-        `max-w-[325px] w-full h-[50px] rounded-[25px] flex items-center justify-center rotate-0 transition
+      className={twMerge(
+        `max-w-[325px] w-full h-[50px] rounded-[25px] flex items-center justify-center text-sb-18 tracking-[-0.72px] rotate-0 transition
         ${disabled
           ? 'bg-gray-150 border-gray-150 text-gray-750 cursor-not-allowed'
           : 'border border-primary bg-white text-primary cursor-pointer active:scale-95 active:brightness-95'
         }`,
         className
-      )} text-SB-18`}
+      )}
       {...props}
     >
       {label}

--- a/src/hooks/useIsStandalone.ts
+++ b/src/hooks/useIsStandalone.ts
@@ -1,0 +1,6 @@
+// 지금 이 페이지가 홈 화면에 설치되어 standalone(PWA)으로 실행 중인지 확인.
+export const isStandalone = () =>
+  // 표준 방법: 브라우저에가 현재 standalone 모드인지 확인 
+  window.matchMedia('(display-mode: standalone)').matches ||
+  // 구형 iOS Safari 전용 값
+  (window.navigator as { standalone?: boolean }).standalone === true;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import Icon from '../components/Icon';
-import { isStandalone } from '../hooks/useIsStandalone';
+import { isStandalone } from '../utils/isStandalone';
 
 type MainLayoutProps = {
   title: string;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import Icon from '../components/Icon';
+import { isStandalone } from '../hooks/useIsStandalone';
 
 type MainLayoutProps = {
   title: string;
@@ -9,6 +10,8 @@ type MainLayoutProps = {
 };
 
 const MainLayout = ({ title, rightElement, onBack, children }: MainLayoutProps) => {
+  // PWA(홈 화면 설치)는 원래 값(10)이 이미 잘 맞아서 유지, 브라우저 탭은 Figma 스펙(15) 적용
+  const headerPaddingTop = isStandalone() ? 10 : 15;
   return (
     <div
       className='min-h-screen flex justify-center bg-[#f5f6f7] [container-type:inline-size]'
@@ -18,8 +21,7 @@ const MainLayout = ({ title, rightElement, onBack, children }: MainLayoutProps) 
         <header
           className='sticky left-0 right-0 top-0 z-50 grid w-full grid-cols-[24px_1fr_24px] items-center bg-white px-[25px] py-[10px]'
           style={{
-            paddingTop: 'calc(10px + env(safe-area-inset-top, 0px))',
-            top: 'env(safe-area-inset-top, 0px)',
+            paddingTop: `calc(${headerPaddingTop}px + env(safe-area-inset-top, 0px))`,
           }}
         >
           <button type='button' className='flex items-center justify-start' onClick={onBack}>

--- a/src/layouts/headers/EditHeader.tsx
+++ b/src/layouts/headers/EditHeader.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import Icon, {type IconName} from '../../components/Icon';
 import { useNavigate } from 'react-router-dom';
-import { isStandalone } from '../../hooks/useIsStandalone';
+import { isStandalone } from '../../utils/isStandalone';
 
 type LeftAction = {
   icon?: IconName;

--- a/src/layouts/headers/EditHeader.tsx
+++ b/src/layouts/headers/EditHeader.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import Icon, {type IconName} from '../../components/Icon';
 import { useNavigate } from 'react-router-dom';
+import { isStandalone } from '../../hooks/useIsStandalone';
 
 type LeftAction = {
   icon?: IconName;
@@ -19,13 +20,14 @@ export const EditHeader = ({ title, rightElement, leftAction }: EditHeaderProps)
   const navigate = useNavigate();
   const handleLeftClick =  leftAction?.onClick ?? (() => navigate(-1));
   const leftLabel = leftAction?.ariaLabel ?? "취소";
+  // PWA(홈 화면 설치)는 원래 값(10)이 이미 잘 맞아서 유지, 브라우저 탭은 Figma 스펙(15) 적용
+  const headerPaddingTop = isStandalone() ? 10 : 15;
   return (
     <header
       //고정 헤더.
       className='sticky left-0 right-0 top-0 z-50 inline-flex w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size] relative'
       style={{
-        paddingTop: 'calc(10px + env(safe-area-inset-top, 0px))',
-        top: 'env(safe-area-inset-top, 0px)',
+        paddingTop: `calc(${headerPaddingTop}px + env(safe-area-inset-top, 0px))`,
       }}
       role='banner'
     >

--- a/src/layouts/headers/EditHeader.tsx
+++ b/src/layouts/headers/EditHeader.tsx
@@ -25,7 +25,7 @@ export const EditHeader = ({ title, rightElement, leftAction }: EditHeaderProps)
   return (
     <header
       //고정 헤더.
-      className='sticky left-0 right-0 top-0 z-50 inline-flex w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size] relative'
+      className='sticky left-0 right-0 top-0 z-50 inline-flex w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size]'
       style={{
         paddingTop: `calc(${headerPaddingTop}px + env(safe-area-inset-top, 0px))`,
       }}

--- a/src/layouts/headers/HomeHeader.tsx
+++ b/src/layouts/headers/HomeHeader.tsx
@@ -54,7 +54,6 @@ export const HomeHeader = ({
         ...(useSafeArea
           ? {
               paddingTop: 'calc(15px + env(safe-area-inset-top, 0px))',
-              top: 'env(safe-area-inset-top, 0px)',
             }
           : null),
         ...style,

--- a/src/layouts/headers/LoginHeader.tsx
+++ b/src/layouts/headers/LoginHeader.tsx
@@ -1,5 +1,5 @@
 import Icon from '../../components/Icon';
-import { isStandalone } from '../../hooks/useIsStandalone';
+import { isStandalone } from '../../utils/isStandalone';
 
 interface LoginHeaderProps {
   onBack: () => void;

--- a/src/layouts/headers/LoginHeader.tsx
+++ b/src/layouts/headers/LoginHeader.tsx
@@ -1,17 +1,19 @@
 import Icon from '../../components/Icon';
+import { isStandalone } from '../../hooks/useIsStandalone';
 
 interface LoginHeaderProps {
   onBack: () => void;
 }
 
 export const LoginHeader = ({ onBack }: LoginHeaderProps) => {
+  // PWA(홈 화면 설치)는 원래 값(10)이 이미 잘 맞아서 유지, 브라우저 탭은 Figma 스펙(15) 적용
+  const headerPaddingTop = isStandalone() ? 10 : 15;
 
   return (
     <header
       className='sticky left-0 right-0 top-0 z-50 inline-flex w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size] relative'
       style={{
-        paddingTop: 'calc(10px + env(safe-area-inset-top, 0px))',
-        top: 'env(safe-area-inset-top, 0px)',
+        paddingTop: `calc(${headerPaddingTop}px + env(safe-area-inset-top, 0px))`,
       }}
       role='banner'
     >

--- a/src/layouts/headers/MainHeader.tsx
+++ b/src/layouts/headers/MainHeader.tsx
@@ -76,7 +76,7 @@ export const MainHeader = ({
 
   return (
     <header
-      className={twMerge('sticky left-0 right-0 top-0 z-50 inline-flex min-h-[48px] w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size] relative', className)}
+      className={twMerge('sticky left-0 right-0 top-0 z-50 inline-flex min-h-[48px] w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size]', className)}
       style={{
         // top은 0을 유지해 배경이 노치까지 이어지게 하고, safe-area는 paddingTop에서만 더함
         // (top에도 safe area 더하면 이중 계산되어 콘텐츠가 필요 이상으로 밀려남)

--- a/src/layouts/headers/MainHeader.tsx
+++ b/src/layouts/headers/MainHeader.tsx
@@ -5,6 +5,7 @@ import Badge from '../../components/Badge';
 import Icon, { type IconName } from '../../components/Icon';
 import { logout } from '../../api/profileApi';
 import { useAuthStore } from '../../store/useAuthStore';
+import { isStandalone } from '../../hooks/useIsStandalone';
 
 type HeaderAction = {
   icon: IconName;
@@ -44,11 +45,13 @@ export const MainHeader = ({
   showBadge,
   isAdmin,
   className,
-  headerPaddingTop = 10,
+  headerPaddingTop,
 }: MainHeaderProps) => {
   const navigate = useNavigate();
   const setLogout = useAuthStore((s) => s.setLogout);
   const authUserId = useAuthStore((s) => s.user?.id);
+  // PWA(홈 화면 설치)는 원래 값(10)이 이미 잘 맞아서 유지, 브라우저 탭은 Figma 스펙(15) 적용
+  const effectiveHeaderPaddingTop = headerPaddingTop ?? (isStandalone() ? 10 : 15);
 
   const handleLogout = async () => {
     try {
@@ -75,8 +78,9 @@ export const MainHeader = ({
     <header
       className={twMerge('sticky left-0 right-0 top-0 z-50 inline-flex min-h-[48px] w-full items-center bg-white px-[25px] py-[10px] [container-type:inline-size] relative', className)}
       style={{
-        paddingTop: `calc(${headerPaddingTop}px + env(safe-area-inset-top, 0px))`,
-        top: 'env(safe-area-inset-top, 0px)',
+        // top은 0을 유지해 배경이 노치까지 이어지게 하고, safe-area는 paddingTop에서만 더함
+        // (top에도 safe area 더하면 이중 계산되어 콘텐츠가 필요 이상으로 밀려남)
+        paddingTop: `calc(${effectiveHeaderPaddingTop}px + env(safe-area-inset-top, 0px))`,
       }}
       role='banner'
     >

--- a/src/layouts/headers/MainHeader.tsx
+++ b/src/layouts/headers/MainHeader.tsx
@@ -5,7 +5,7 @@ import Badge from '../../components/Badge';
 import Icon, { type IconName } from '../../components/Icon';
 import { logout } from '../../api/profileApi';
 import { useAuthStore } from '../../store/useAuthStore';
-import { isStandalone } from '../../hooks/useIsStandalone';
+import { isStandalone } from '../../utils/isStandalone';
 
 type HeaderAction = {
   icon: IconName;

--- a/src/pages/activity/ActivityPage.tsx
+++ b/src/pages/activity/ActivityPage.tsx
@@ -34,8 +34,8 @@ export const ActivityPage = () => {
   return (
     <FullLayout
       headerSlot={
-        isSearchOpen ? (
-          <div className='bg-white top-0 z-50 sticky'>
+        <div className='sticky top-0 z-50 bg-white'>
+          {isSearchOpen ? (
             <div className='px-[25px]'>
               <div className='mx-auto flex w-full max-w-[720px] items-center gap-[15px] py-[10px]'>
                 <button
@@ -58,25 +58,23 @@ export const ActivityPage = () => {
                 />
               </div>
             </div>
-          </div>
-        ) : (
-          <MainHeader
-            title='대외활동'
-            leftIcon='empty'
-            rightActions={[
-              {
-                icon: 'search',
-                onClick: () => setIsSearchOpen(true),
-                ariaLabel: '검색 열기',
-              },
-            ]}
-          />
-        )
+          ) : (
+            <MainHeader
+              title='대외활동'
+              leftIcon='empty'
+              rightActions={[
+                {
+                  icon: 'search',
+                  onClick: () => setIsSearchOpen(true),
+                  ariaLabel: '검색 열기',
+                },
+              ]}
+            />
+          )}
+          <Tabs tabs={tabItems} activeId={activeTab} onChange={(id) => setActiveTab(id as ActivityPostTab)} />
+        </div>
       }
     >
-      <div className='bg-white'>
-        <Tabs tabs={tabItems} activeId={activeTab} onChange={(id) => setActiveTab(id as ActivityPostTab)} />
-      </div>
       <div>{renderTab()}</div>
     </FullLayout>
   );

--- a/src/pages/admin/AdminWritePage.tsx
+++ b/src/pages/admin/AdminWritePage.tsx
@@ -31,8 +31,8 @@ export const AdminWritePage = () => {
   return (
     <AdminFullLayout
       headerSlot={
-        isSearchOpen ? (
-          <div className='bg-white top-0 z-50 sticky'>
+        <div className='sticky top-0 z-50 bg-white'>
+          {isSearchOpen ? (
             <div className='px-[25px]'>
               <div className='mx-auto flex w-full max-w-[720px] items-center gap-[15px] py-[10px]'>
                 <button
@@ -55,24 +55,22 @@ export const AdminWritePage = () => {
                 />
               </div>
             </div>
-          </div>
-        ) : (
-          <MainHeader
-            title='대외활동 등록'
-            rightActions={[
-              {
-                icon: 'search',
-                onClick: () => setIsSearchOpen(true),
-                ariaLabel: '검색 열기',
-              },
-            ]}
-          />
-        )
+          ) : (
+            <MainHeader
+              title='대외활동 등록'
+              rightActions={[
+                {
+                  icon: 'search',
+                  onClick: () => setIsSearchOpen(true),
+                  ariaLabel: '검색 열기',
+                },
+              ]}
+            />
+          )}
+          <Tabs tabs={tabItems} activeId={activeTab} onChange={(id) => setActiveTab(id as ActivityPostTab)} />
+        </div>
       }
     >
-      <div className='bg-white'>
-        <Tabs tabs={tabItems} activeId={activeTab} onChange={(id) => setActiveTab(id as ActivityPostTab)} />
-      </div>
       <div>{renderTab()}</div>
     </AdminFullLayout>
   );

--- a/src/pages/auth/FindAccountPage.tsx
+++ b/src/pages/auth/FindAccountPage.tsx
@@ -28,7 +28,6 @@ export const FindAccountPage = () => {
             headerSlot={
                 <MainHeader
                     title={headerTitle}
-                    headerPaddingTop={68}
                     leftAction={isPasswordResetStep
                         ? { onClick: () => setIsPasswordResetStep(false) }
                         : undefined

--- a/src/pages/auth/FindAccountPage.tsx
+++ b/src/pages/auth/FindAccountPage.tsx
@@ -26,24 +26,24 @@ export const FindAccountPage = () => {
     return (
         <HeaderLayout
             headerSlot={
-                <MainHeader
-                    title={headerTitle}
-                    leftAction={isPasswordResetStep
-                        ? { onClick: () => setIsPasswordResetStep(false) }
-                        : undefined
-                    }
-                />
+                <div className='sticky top-0 z-50 bg-white'>
+                    <MainHeader
+                        title={headerTitle}
+                        leftAction={isPasswordResetStep
+                            ? { onClick: () => setIsPasswordResetStep(false) }
+                            : undefined
+                        }
+                    />
+                    <Tabs
+                        tabs={tabs}
+                        activeId={tab ?? 'id'} // ?? : nullish 병합 연산자 -> 왼쪽이 null || undefined 이면 오른쪽값 사용
+                        onChange={(id) => navigate(`/find-account/${id}`, {replace: true})}
+                        isVisible={!isPasswordResetStep}
+                    />
+                </div>
             }
         >
-            <Tabs
-                tabs={tabs}
-                activeId={tab ?? 'id'} // ?? : nullish 병합 연산자 -> 왼쪽이 null || undefined 이면 오른쪽값 사용
-                onChange={(id) => navigate(`/find-account/${id}`, {replace: true})}
-                isVisible={!isPasswordResetStep}
-            >
-                {tab === 'id' ? <FindIdForm /> : <FindPwForm isPasswordResetStep = {isPasswordResetStep} onCodeVerified = {() => setIsPasswordResetStep(true)} />}
-            </Tabs>
-
+            {tab === 'id' ? <FindIdForm /> : <FindPwForm isPasswordResetStep = {isPasswordResetStep} onCodeVerified = {() => setIsPasswordResetStep(true)} />}
         </HeaderLayout>
     )
 }

--- a/src/pages/coffee-chat/ChatListPage.tsx
+++ b/src/pages/coffee-chat/ChatListPage.tsx
@@ -52,70 +52,71 @@ export const ChatListPage = () => {
   return (
     <FullLayout
       headerSlot={
-        <MainHeader
-          title="커피챗"
-          leftIcon="empty"
-          rightActions={[
-            { icon: 'coffeeChat', onClick: () => navigate('/chat/requests') }
-          ]}
-          showBadge={requestExists}
-        />
+        <div className="sticky top-0 z-50 bg-white">
+          <MainHeader
+            title="커피챗"
+            leftIcon="empty"
+            rightActions={[
+              { icon: 'coffeeChat', onClick: () => navigate('/chat/requests') }
+            ]}
+            showBadge={requestExists}
+          />
+          <Tabs
+            tabs={tabs}
+            activeId={activeId}
+            onChange={(id) => setActiveId(id as ChatRoomListItemType)}
+          />
+        </div>
       }
     >
-      <Tabs
-        tabs={tabs}
-        activeId={activeId}
-        onChange={(id) => setActiveId(id as ChatRoomListItemType)}
-      >
-        {/* 검색영역 */}
-        <section className="w-full px-[25px] py-[20px] ">
-          <div className="relative">
-              <svg width="18" height="18" viewBox="0 0 20 20" fill="none"
-              className="absolute left-[19px] top-[50%] translate-y-[-50%]">
-                  <path 
-                      d="M18.7508 18.7508L13.5538 13.5538M13.5538 13.5538C14.9604 12.1472 15.7506 10.2395 15.7506 8.25028C15.7506 6.26108 14.9604 4.35336 13.5538 2.94678C12.1472 1.54021 10.2395 0.75 8.25028 0.75C6.26108 0.75 4.35336 1.54021 2.94678 2.94678C1.54021 4.35336 0.75 6.26108 0.75 8.25028C0.75 10.2395 1.54021 12.1472 2.94678 13.5538C4.35336 14.9604 6.26108 15.7506 8.25028 15.7506C10.2395 15.7506 12.1472 14.9604 13.5538 13.5538Z" 
-                      stroke="#646464" 
-                      strokeWidth="1.5" 
-                      strokeLinecap="round" 
-                      strokeLinejoin="round"/>
-              </svg>
-              <input
-                  type="text"
-                  name="searchTags"
-                  placeholder="채팅방, 대화 내용 검색"
-                  aria-label="채팅방 또는 대화 내용 검색"
-                  value={searchQuery}
-                  onChange={(e) => {
-                    setSearchQuery(e.target.value)
-                  }}
-                  className="w-full h-[40px] pl-[52px] pr-[19px] py-[8px] rounded-[30px] bg-gray-150 text-gray-750 text-r-16 placeholder:text-gray-650 focus:outline-none"
-              />
-          </div>
-        </section>
+      {/* 검색영역 */}
+      <section className="w-full px-[25px] py-[20px] ">
+        <div className="relative">
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none"
+            className="absolute left-[19px] top-[50%] translate-y-[-50%]">
+                <path
+                    d="M18.7508 18.7508L13.5538 13.5538M13.5538 13.5538C14.9604 12.1472 15.7506 10.2395 15.7506 8.25028C15.7506 6.26108 14.9604 4.35336 13.5538 2.94678C12.1472 1.54021 10.2395 0.75 8.25028 0.75C6.26108 0.75 4.35336 1.54021 2.94678 2.94678C1.54021 4.35336 0.75 6.26108 0.75 8.25028C0.75 10.2395 1.54021 12.1472 2.94678 13.5538C4.35336 14.9604 6.26108 15.7506 8.25028 15.7506C10.2395 15.7506 12.1472 14.9604 13.5538 13.5538Z"
+                    stroke="#646464"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"/>
+            </svg>
+            <input
+                type="text"
+                name="searchTags"
+                placeholder="채팅방, 대화 내용 검색"
+                aria-label="채팅방 또는 대화 내용 검색"
+                value={searchQuery}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value)
+                }}
+                className="w-full h-[40px] pl-[52px] pr-[19px] py-[8px] rounded-[30px] bg-gray-150 text-gray-750 text-r-16 placeholder:text-gray-650 focus:outline-none"
+            />
+        </div>
+      </section>
 
-        <ul>
-          {
-            // 검색어 여부로 분기 렌더링
-            // todo 길게 클릭 후 삭제 기능 추가
-            searchQuery ? searchFilteredChatRoomList(searchQuery).map((chatRoom) => (
-            <ChatList 
-              key={chatRoom.roomId} 
-              chatRoom={chatRoom} 
-              isClosed={chatRoom.isClosed}
-              searchQuery={searchQuery} 
-              onClick={() => handleChatRoomClick(chatRoom.roomId)}
-            />
-          )) : filteredChatRoomList.map((chatRoom) => (
-            <ChatList 
-              key={chatRoom.roomId} 
-              isClosed={chatRoom.isClosed}
-              chatRoom={chatRoom} 
-              onClick={() => handleChatRoomClick(chatRoom.roomId)}
-            />
-          ))}
-        </ul>
-        <PopUp isOpen={isLoading} type="loading" />
-      </Tabs>
+      <ul>
+        {
+          // 검색어 여부로 분기 렌더링
+          // todo 길게 클릭 후 삭제 기능 추가
+          searchQuery ? searchFilteredChatRoomList(searchQuery).map((chatRoom) => (
+          <ChatList
+            key={chatRoom.roomId}
+            chatRoom={chatRoom}
+            isClosed={chatRoom.isClosed}
+            searchQuery={searchQuery}
+            onClick={() => handleChatRoomClick(chatRoom.roomId)}
+          />
+        )) : filteredChatRoomList.map((chatRoom) => (
+          <ChatList
+            key={chatRoom.roomId}
+            isClosed={chatRoom.isClosed}
+            chatRoom={chatRoom}
+            onClick={() => handleChatRoomClick(chatRoom.roomId)}
+          />
+        ))}
+      </ul>
+      <PopUp isOpen={isLoading} type="loading" />
     </FullLayout>
   );
 };

--- a/src/pages/coffee-chat/ChatRequestListPage.tsx
+++ b/src/pages/coffee-chat/ChatRequestListPage.tsx
@@ -77,24 +77,27 @@ export const ChatRequestListPage = () => {
   return (
     <HeaderLayout
       headerSlot={
-        <MainHeader
-          title="요청" />
+        <div className="sticky top-0 z-50 bg-white">
+          <MainHeader
+            title="요청" />
+          <Tabs
+            tabs={tabs}
+            activeId={activeId}
+            onChange={(id) => setActiveId(id as ChatRoomListItemType)}
+          />
+        </div>
       }
     >
-      <Tabs
-        tabs={tabs}
-        activeId={activeId}
-        onChange={(id) => setActiveId(id as ChatRoomListItemType)}
-      >
+      <div className="flex-1 overflow-y-auto min-h-0">
         <ul>
           {
-            activeId === 'TEAM_RECRUIT' ? 
+            activeId === 'TEAM_RECRUIT' ?
               // Object.entries : Object -> Array ([index0, index1])
               Object.entries(filteredChatRoomListByPost).map(([key, chatRoomList]) => {
-                
+
                 const isOpen = openPostTitle === key;
                 const requestCount = chatRoomList.length;
-                
+
                 return (
                   <li key={key} className="flex flex-col">
                     <ChatPostAccordian
@@ -106,10 +109,10 @@ export const ChatRequestListPage = () => {
                     {isOpen && (
                       <ul>
                         {chatRoomList.map((chatRoom) => (
-                          <ChatList 
-                            key={chatRoom.roomId} 
-                            chatRoom={chatRoom} 
-                            isFirstPaddingDisabled={false} 
+                          <ChatList
+                            key={chatRoom.roomId}
+                            chatRoom={chatRoom}
+                            isFirstPaddingDisabled={false}
                             onClick={() => handleChatRoomClick(chatRoom.roomId)}
                           />
                         ))}
@@ -118,25 +121,24 @@ export const ChatRequestListPage = () => {
                   </li>
                 )
               })
-            : 
+            :
               filteredChatRoomList.map((chatRoom) => (
-                <ChatList 
-                  key={chatRoom.roomId} 
-                  chatRoom={chatRoom} 
-                  isFirstPaddingDisabled={false} 
+                <ChatList
+                  key={chatRoom.roomId}
+                  chatRoom={chatRoom}
+                  isFirstPaddingDisabled={false}
                   onClick={() => handleChatRoomClick(chatRoom.roomId)}
                 />
               ))
           }
         </ul>
 
-
         <AllRequestDeleteButton
           requestCount={currentDeleteCount}
           onClick={handleDeleteAll}
         />
-        <PopUp isOpen={isLoading} type="loading" />
-      </Tabs>
+      </div>
+      <PopUp isOpen={isLoading} type="loading" />
     </HeaderLayout>
   );
 };

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -343,8 +343,8 @@ export const CommunityPage = () => {
   return (
     <HeaderLayout
       headerSlot={
-        isSearchOpen && activeTab !== 'all' ? (
-          <div className='bg-white'>
+        <div className='sticky top-0 z-50 bg-white'>
+          {isSearchOpen && activeTab !== 'all' ? (
             <div className='px-[25px]'>
               <div className='mx-auto flex w-full max-w-[720px] items-center gap-[15px] py-[10px]'>
                 <button
@@ -366,32 +366,30 @@ export const CommunityPage = () => {
                 />
               </div>
             </div>
-          </div>
-        ) : (
-          <MainHeader
-            title='커뮤니티'
-            leftAction={{
-              onClick: () => navigate('/home', { replace: true }),
-              ariaLabel: '홈으로 이동',
-            }}
-            rightActions={
-              activeTab === 'all'
-                ? []
-                : [
-                  {
-                    icon: 'search',
-                    onClick: () => setIsSearchOpen(true),
-                    ariaLabel: '검색 열기',
-                  },
-                ]
-            }
-          />
-        )
+          ) : (
+            <MainHeader
+              title='커뮤니티'
+              leftAction={{
+                onClick: () => navigate('/home', { replace: true }),
+                ariaLabel: '홈으로 이동',
+              }}
+              rightActions={
+                activeTab === 'all'
+                  ? []
+                  : [
+                    {
+                      icon: 'search',
+                      onClick: () => setIsSearchOpen(true),
+                      ariaLabel: '검색 열기',
+                    },
+                  ]
+              }
+            />
+          )}
+          <Tabs tabs={tabItems} activeId={activeTab} onChange={setActiveTab} />
+        </div>
       }
     >
-      <div className='bg-white'>
-        <Tabs tabs={tabItems} activeId={activeTab} onChange={setActiveTab} />
-      </div>
       <div>{renderTab()}</div>
     </HeaderLayout>
   );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -174,7 +174,7 @@ export const HomePage = () => {
         // 홈 1번 영역: 인사말, 커피챗 요청, 포인트/커뮤니티 카드 틀 구성
         <FullLayout>
             <div className="mx-auto w-full max-w-[430px] bg-white">
-                <section className="bg-primary px-[25px] pt-[64px] pb-[62px]">
+                <section className="bg-primary px-[25px] pt-[22px] pb-[62px]">
                     <HomeHeader
                         showBadge={hasUnreadNotifications}
                         variant="onPrimary"

--- a/src/pages/my-page/MypageFollowerPage.tsx
+++ b/src/pages/my-page/MypageFollowerPage.tsx
@@ -81,20 +81,21 @@ export const FollowerPage = () => {
     return (
         <HeaderLayout
             headerSlot={
-                <MainHeader
-                    title="팔로워"
-                />
+                <div className="sticky top-0 z-50 bg-white">
+                    <MainHeader
+                        title="팔로워"
+                    />
+                    {/* 탭 */}
+                    <Tabs
+                        tabs={TABS}
+                        activeId={activeTab}
+                        onChange={(id) => setActiveTab(id as TabType)}
+                        className="px-[21px]"
+                    />
+                </div>
             }
         >
             <div className="w-full h-full bg-white flex flex-col">
-                {/* 탭 */}
-                <Tabs
-                    tabs={TABS}
-                    activeId={activeTab}
-                    onChange={(id) => setActiveTab(id as TabType)}
-                    className="px-[21px]"
-                />
-
                 {/* 검색창 */}
                 <div className="w-full px-[25px] pt-[20px] pb-[10px]">
                     <div className="relative">

--- a/src/pages/my-page/sidebar/MyBookmarksPage.tsx
+++ b/src/pages/my-page/sidebar/MyBookmarksPage.tsx
@@ -286,19 +286,21 @@ export const MyBookmarksPage = () => {
     return (
         <HeaderLayout
             headerSlot={
-                <MainHeader
-                    title="북마크"
-                    leftAction={{onClick: () => navigate(-1)}}
-                />
+                <div className="sticky top-0 z-50 bg-white">
+                    <MainHeader
+                        title="북마크"
+                        leftAction={{onClick: () => navigate(-1)}}
+                    />
+                    {/* Tabs */}
+                    <Tabs
+                        tabs={TAB_ITEMS}
+                        activeId={activeTab}
+                        onChange={(id) => setActiveTab(id as TabType)}
+                    />
+                </div>
             }
         >
             <div className="w-full bg-white h-full flex flex-col min-h-0">
-                {/* Tabs */}
-                <Tabs
-                    tabs={TAB_ITEMS}
-                    activeId={activeTab}
-                    onChange={(id) => setActiveTab(id as TabType)}
-                />
                 <div ref={listRef} className="flex-1 overflow-y-auto min-h-0">
                     {/* Sort Selector */}
                     <div className="flex justify-end px-[25px] pt-[20px]">

--- a/src/pages/my-page/sidebar/MyPostPage.tsx
+++ b/src/pages/my-page/sidebar/MyPostPage.tsx
@@ -277,19 +277,20 @@ export const MyPostsPage = () => {
     return (
         <HeaderLayout
             headerSlot={
-                <MainHeader
-                    title="작성한 글"
-                    leftAction={{ onClick: () => navigate(-1) }}
-                />
+                <div className="sticky top-0 z-50 bg-white">
+                    <MainHeader
+                        title="작성한 글"
+                        leftAction={{ onClick: () => navigate(-1) }}
+                    />
+                    <Tabs
+                        tabs={TAB_ITEMS}
+                        activeId={activeTab}
+                        onChange={(id) => setActiveTab(id as TabType)}
+                    />
+                </div>
             }
         >
             <div className="w-full bg-white h-full flex flex-col min-h-0">
-                <Tabs
-                    tabs={TAB_ITEMS}
-                    activeId={activeTab}
-                    onChange={(id) => setActiveTab(id as TabType)}
-                />
-
                 <div ref={listRef} className="flex-1 overflow-y-auto min-h-0">
                     {/* Sort Selector */}
                     <div className="flex justify-end px-[25px] pt-[20px]">

--- a/src/utils/isStandalone.ts
+++ b/src/utils/isStandalone.ts
@@ -1,6 +1,6 @@
 // 지금 이 페이지가 홈 화면에 설치되어 standalone(PWA)으로 실행 중인지 확인.
 export const isStandalone = () =>
-  // 표준 방법: 브라우저에가 현재 standalone 모드인지 확인 
+  // 표준 방법: 브라우저가 현재 standalone 모드인지 확인
   window.matchMedia('(display-mode: standalone)').matches ||
   // 구형 iOS Safari 전용 값
   (window.navigator as { standalone?: boolean }).standalone === true;


### PR DESCRIPTION
## 💡 Related issue

- closes #138

## ✨ Description

**1. Header Padding top 조절**
- iIsStandalone 함수로 PWA(standalone) 모드인지 판단 
- 브라우저 <-> PWA시에 다른 padding top 값 적용 (15px vs 10px)

**2. Header, Tabs 스크롤 방지**
- relative 속성 제거 -> sticky 속성 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved header spacing for standalone app and browser modes, including safer device-area handling.
  * Headers and tabs now remain visible while scrolling across activity, community, chat, account, and bookmark pages.
  * Added support for detecting standalone/PWA display mode.

* **Bug Fixes**
  * Improved button styling consistency for disabled states.
  * Reduced excess spacing at the top of the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->